### PR TITLE
Store EC coded blocks on RAID5 (always)

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.java
@@ -7415,8 +7415,10 @@ private void commitOrCompleteLastBlock(
       }
     }
 
-    // TODO lookup the inodeid, then lookup the storagePolicyID
-    byte storagePolicyID = BlockStoragePolicySuite.ID_UNSPECIFIED;
+    // We always want to store Erasure Coded files on RAID5 volumes, but can
+    // fall back to DISK
+    byte storagePolicyID = HdfsConstants.RAID5_STORAGE_POLICY_ID;
+    BlockStoragePolicy policy = BlockStoragePolicySuite.getPolicy(storagePolicyID);
 
     BlockPlacementPolicyDefault placementPolicy = (BlockPlacementPolicyDefault)
         getBlockManager().getBlockPlacementPolicy();
@@ -7425,8 +7427,7 @@ private void commitOrCompleteLastBlock(
     DatanodeStorageInfo[] descriptors = placementPolicy
         .chooseTarget(isParity ? parityPath : sourcePath,
             isParity ? 1 : status.getEncodingPolicy().getTargetReplication(),
-            null, chosenStorages, false, excluded, block.getBlockSize(),
-            BlockStoragePolicySuite.getPolicy(storagePolicyID));
+            null, chosenStorages, false, excluded, block.getBlockSize(), policy);
 
     return new LocatedBlock(block.getBlock(), descriptors);
   }

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/BaseEncodingManager.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.StringUtils;
 import org.json.JSONException;
@@ -249,6 +250,14 @@ public abstract class BaseEncodingManager extends EncodingManager {
         statistics.remainingSize += diskSpace;
         return false;
       }
+
+      // Set the storage policy to RAID5 for disk-fault tolerance
+      srcFs.setStoragePolicy(sourceFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
+      // The policy is now updated, but did not change the locations of
+      // blocks yet. This only happens when we trigger the Mover.
+      // TODO
+      // Mover.trigger(sourceFile);
+
     } catch (IOException e) {
       if (out != null) {
         out.close();

--- a/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
+++ b/hops-erasure-coding/src/main/java/io/hops/erasure_coding/Encoder.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.hdfs.DFSOutputStream;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
 import org.apache.hadoop.util.Progressable;
 
 import java.io.File;
@@ -144,6 +145,11 @@ public class Encoder {
     }
     FSDataOutputStream out = parityFs.create(parityFile, true,
         conf.getInt("io.file.buffer.size", 64 * 1024), tmpRepl, blockSize);
+
+    // Set the storage policy to RAID5 for disk-fault tolerance
+    if(parityFs instanceof DistributedFileSystem) {
+      ((DistributedFileSystem) parityFs).setStoragePolicy(parityFile, HdfsConstants.RAID5_STORAGE_POLICY_NAME);
+    }
 
     DFSOutputStream dfsOut = (DFSOutputStream) out.getWrappedStream();
     dfsOut.enableParityStream(codec.getStripeLength(), codec.getParityLength(),


### PR DESCRIPTION
Not ready/tested yet.

We should check whether this implementation (it's a bit hacky with hardcoded settings to always store EC coded files on RAID5) is really what we want.

Also, the Mover first has to be implemented&tested (now the Balancer might pick some stuff up, but definitely not everything), otherwise the storage policy will be changed but blocks won't be moved in accordance with the new policy.
